### PR TITLE
Support for ReSharper 8.1

### DIFF
--- a/resharper-nuget/mstest-templates.nuspec
+++ b/resharper-nuget/mstest-templates.nuspec
@@ -3,10 +3,11 @@
   <metadata>
     <id>ReSharper.Templates.mstest</id>
     <title>MSTest Live Templates</title>
-    <version>1.0.0.0</version>
+    <version>1.0.0.1</version>
     <authors>Daniel Sack</authors>
     <owners>Daniel Sack</owners>
     <description>A set of 'MSTest' Live Templates to quickly generate class, method, attributes entries.</description>
+    <releaseNotes>Support for ReSharper 8.1</releaseNotes>
     <projectUrl>https://github.com/DanielTheCoder/ReSharper.Templates</projectUrl>
     <!-- <iconUrl>http://resharper-plugins.jetbrains.com/Content/Images/packageReSharper.png</iconUrl> -->
     <copyright>Copyright &#169; 2013 Daniel Sack</copyright>
@@ -17,6 +18,6 @@
     <tags>resharper templates mstest class testinitialize testcleanup testmethod</tags>
   </metadata>
   <files>
-    <file src="..\downloads\mstest-templates.dotSettings" target="ReSharper\v8.0\settings" />
+    <file src="..\downloads\mstest-templates.dotSettings" target="ReSharper\vAny\settings" />
   </files>
 </package>

--- a/resharper-nuget/todo-templates.nuspec
+++ b/resharper-nuget/todo-templates.nuspec
@@ -3,10 +3,11 @@
   <metadata>
     <id>ReSharper.Templates.todo</id>
     <title>ToDo Live Templates</title>
-    <version>1.0.0.0</version>
+    <version>1.0.0.1</version>
     <authors>Daniel Sack</authors>
     <owners>Daniel Sack</owners>
     <description>A set 'ToDo' Live Templates to quickly generate ToDo, Notes, Bug entries.</description>
+    <releaseNotes>Support for ReSharper 8.1</releaseNotes>
     <projectUrl>https://github.com/DanielTheCoder/ReSharper.Templates</projectUrl>
     <!-- <iconUrl>http://resharper-plugins.jetbrains.com/Content/Images/packageReSharper.png</iconUrl> -->
     <copyright>Copyright &#169; 2013 Daniel Sack</copyright>
@@ -17,6 +18,6 @@
     <tags>resharper templates todo note bug</tags>
   </metadata>
   <files>
-    <file src="..\downloads\todo-templates.dotSettings" target="ReSharper\v8.0\settings" />
+    <file src="..\downloads\todo-templates.dotSettings" target="ReSharper\vAny\settings" />
   </files>
 </package>


### PR DESCRIPTION
Puts the settings file into a version independent folder, so it's loaded by 8.0 and the 8.1 EAP. The package doesn't need to be pre-release, as the file format won't change before RTM
